### PR TITLE
windows build with python3 and up-to-date pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ windows: ## Build Windows_x64 binaries
 		-v "${PWD}:/impacket" \
 		-w "/impacket" \
 		--entrypoint="/impacket/build_scripts/build_windows.sh" \
-		cdrx/pyinstaller-windows:python2
+		cdrx/pyinstaller-windows:python3
 
 clean: cleanspec ## Remove all build artifacts
 	rm -rf dist/* build/*

--- a/build_scripts/build_windows.sh
+++ b/build_scripts/build_windows.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 cd "${ROOT}"
 
+# Update pip (so that compiled packages are used if rust is required)
+python -m pip install --upgrade pip
+
 # Install impacket
 pip install .
 


### PR DESCRIPTION
Building the Windows binaries currently fails due to an outdated pip version (the cryptography module requires rust; newer pip versions use a pre-compiled version instead of compiling it locally).

Updating pip in the docker-pyinstaller:python2 container failed, so I switched to python3 which seems to work. Additionally, building the python2 container is not possible anymore as Microsoft removed the download of the VCForPython27.msi file (but I did not try to fix this).

I only tested secretsdump_windows.exe, nothing more. So I'm not sure if switching to python 3 is currently a good idea. However, here are my changes, maybe it's helpful.